### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]
@@ -60,6 +63,9 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/AriasLcr/gait-analyisis/security/code-scanning/3](https://github.com/AriasLcr/gait-analyisis/security/code-scanning/3)

To fix the problem, an explicit `permissions:` block needs to be set in the workflow to define the minimum necessary GitHub token scopes. This is done by adding a `permissions:` block at the workflow root (top-level) or for individual jobs that have different requirements. The safest and simplest approach is to add at the top-level (applies to all jobs), and then override on a per-job basis where more privilege is needed.

For most build/test jobs, `contents: read` is sufficient. The `docker-build` job needs to push to the GitHub Container Registry, so it also needs `packages: write` in addition to `contents: read`.

Concrete steps:
- Insert a `permissions:` block at the top-level with `contents: read` (applies to all jobs by default).
- For the `docker-build` job, explicitly set `permissions:` to `contents: read` and `packages: write` (since it pushes to the registry).
- No new imports, definitions, or methods are needed—just edit the workflow yaml as described above.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
